### PR TITLE
Dependency's version updated

### DIFF
--- a/activejpa-examples/activejpa-examples-vanilla/pom.xml
+++ b/activejpa-examples/activejpa-examples-vanilla/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.16.Final</version>
+			<version>6.2.3.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/activejpa-examples/activejpa-examples-vanilla/src/main/java/org/activejpa/examples/petclinic/PetclinicApplication.java
+++ b/activejpa-examples/activejpa-examples-vanilla/src/main/java/org/activejpa/examples/petclinic/PetclinicApplication.java
@@ -20,7 +20,7 @@ import org.joda.time.DateTime;
 public class PetclinicApplication {
 
     public static void main(String[] args) {
-    		// Ensure we load the Activejpa agent and initialize persistence unit 
+        // Ensure we load the Activejpa agent and initialize persistence unit
         ActiveJpaAgentLoader.instance().loadAgent();
         JPA.instance.addPersistenceUnit("petclinic");
 

--- a/activejpa-test/pom.xml
+++ b/activejpa-test/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.hibernate.javax.persistence</groupId>
 			<artifactId>hibernate-jpa-2.1-api</artifactId>
-			<version>1.0.0.Final</version>
+			<version>1.0.2.Final</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<github.global.server>github</github.global.server>
-		<hibernate.version>5.2.17.Final</hibernate.version>
+		<hibernate.version>5.6.10.Final</hibernate.version>
 		<guava.version>25.0-jre</guava.version>
 		<mockito.version>2.18.3</mockito.version>
 		<testng.version>6.14.3</testng.version>
@@ -24,7 +24,7 @@
 		<commons-beanutils.version>1.9.3</commons-beanutils.version>
 		<commons-lang3.version>3.7</commons-lang3.version>
 		<hsqldb.version>2.4.0</hsqldb.version>
-		<bytebuddy.version>1.8.11</bytebuddy.version>
+		<bytebuddy.version>1.11.0</bytebuddy.version>
 		<lombok.version>1.18.6</lombok.version>
 
 		<!--maven jacoco plugin version -->


### PR DESCRIPTION
### Output on running [PetclinicApplication](https://github.com/ActiveJpa/activejpa/blob/634832fff19391e591950dd17863eef3427054de/activejpa-examples/activejpa-examples-vanilla/src/main/java/org/activejpa/examples/petclinic/PetclinicApplication.java#L22)

![Screenshot 2022-09-20 at 5 21 23 PM](https://user-images.githubusercontent.com/19192080/191250350-abfca510-0606-447b-84fa-b3a4381ef42f.png)

### Test Cases
#### activejpa-core
![Screenshot 2022-09-20 at 6 51 44 PM](https://user-images.githubusercontent.com/19192080/191268902-8a3c277e-da7b-420d-b228-1bafe1e0cdcf.png)

#### activejpa-examples/activejpa-examples-spring
![Screenshot 2022-09-20 at 6 52 48 PM](https://user-images.githubusercontent.com/19192080/191269112-9808d847-a6b2-465e-89a4-2749f1fb48fe.png)

#### activejpa-utils
![Screenshot 2022-09-20 at 6 53 34 PM](https://user-images.githubusercontent.com/19192080/191269293-940fcbdd-9d03-4ce2-af5a-8f1128e97e68.png)

### Libraries Updated:
- [org.hibernate>>hibernate-core](https://mvnrepository.com/artifact/org.hibernate/hibernate-core)
- [org.hibernate>>hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator)
- [org.hibernate.javax.persistence>>hibernate-jpa-2.1-api](https://mvnrepository.com/artifact/org.hibernate.javax.persistence/hibernate-jpa-2.1-api)
- [net.bytebuddy >> byte-buddy-agent](https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy)

### Note
- Updating only the hibernate-core was enough for the service to run properly. However, I updated other related libraries as well so as to ensure all the related libraries are near their latest version. Another reason was to use the improvements that have been done over the years in these libraries. Let me know if you feel any more libraries which are critical need to be updated. 
- Exception to the above point is [net.bytebuddy >> byte-buddy-agent](https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy) , there I could only use up to `1.11.0` because after that the code was breaking.
- While choosing the new library. I tried to ensure that the minor version was the same only. We could have used a new major version but there was possibility that there could be breaking changes in them. 
- While deciding among which one of the multiple recent versions to choose, I chose the one which had the most usage. Therefore, you might notice I haven't used the exact latest version.
